### PR TITLE
mui-example: dark mode

### DIFF
--- a/packages/mui-example/src/main.tsx
+++ b/packages/mui-example/src/main.tsx
@@ -1,14 +1,43 @@
+import {
+  createTheme,
+  CssBaseline,
+  ThemeProvider,
+  useMediaQuery,
+} from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { enAU } from 'date-fns/locale';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
+const Providers = ({ children }: PropsWithChildren) => {
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+
+  const theme = React.useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode: prefersDarkMode ? 'dark' : 'light',
+        },
+      }),
+    [prefersDarkMode]
+  );
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={enAU}>
+        {children}
+      </LocalizationProvider>
+    </ThemeProvider>
+  );
+};
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={enAU}>
+    <Providers>
       <App />
-    </LocalizationProvider>
+    </Providers>
   </React.StrictMode>
 );


### PR DESCRIPTION
Enables dark mode on mui-example, based on system preference.

ionic-example already does this.

## light
![image](https://user-images.githubusercontent.com/6289998/228725324-86e211d1-d986-41ce-a051-102a6c38fd90.png)

## dark
![image](https://user-images.githubusercontent.com/6289998/228725338-ba886890-1d46-4a89-9a88-d40241125c2c.png)
