### PR TITLE
Adds longHint to forms-mui

### DIFF
--- a/.changeset/silver-panthers-reply.md
+++ b/.changeset/silver-panthers-reply.md
@@ -1,0 +1,5 @@
+---
+'@makerx/forms-mui': minor
+---
+
+Added longHint

--- a/packages/mui-example/src/App.tsx
+++ b/packages/mui-example/src/App.tsx
@@ -67,6 +67,8 @@ function App() {
               {helper.textField({
                 label: 'This is required',
                 field: 'myString',
+                hint: 'Some hint text',
+                longHint: 'Some longer hint text',
               })}
             </Grid>
             <Grid item xs={12}>
@@ -89,6 +91,8 @@ function App() {
                 label: 'Text file',
                 field: 'myTextFile',
                 hint: 'Upload a textfile here',
+                longHint:
+                  "Here is some more info that couldn't fit in the hint",
               })}
             </Grid>
             <Grid item xs={12}>

--- a/packages/mui/src/components/date-time-form-item/DateTimeFormItem.tsx
+++ b/packages/mui/src/components/date-time-form-item/DateTimeFormItem.tsx
@@ -22,6 +22,7 @@ export function DateTimeFormItem<
   label,
   className,
   hint,
+  longHint,
   fromISO,
   toISO,
   ...dateTimePickerProps
@@ -36,6 +37,7 @@ export function DateTimeFormItem<
       field={field}
       label={label}
       hint={hint}
+      longHint={longHint}
       disabled={disabled}
       className={className}
     >

--- a/packages/mui/src/components/form-item/FormItem.tsx
+++ b/packages/mui/src/components/form-item/FormItem.tsx
@@ -1,5 +1,6 @@
 import { useFieldMetaData } from '@makerx/forms-core';
-import { InputLabel, Typography } from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { InputLabel, Tooltip, Typography } from '@mui/material';
 import clsx from 'clsx';
 import type { ReactElement } from 'react';
 import { cloneElement } from 'react';
@@ -14,13 +15,21 @@ export interface FormItemProps<
   children: ReactElement;
   label: string;
   hint?: string;
+  longHint?: string;
   field: FieldPath<TSchema>;
   disabled?: boolean;
 }
 
 export function FormItem<
   TSchema extends Record<string, any> = Record<string, any>
->({ className, label, hint, children, field }: FormItemProps<TSchema>) {
+>({
+  className,
+  label,
+  hint,
+  children,
+  field,
+  longHint,
+}: FormItemProps<TSchema>) {
   const {
     formState: { errors },
   } = useFormContext();
@@ -31,6 +40,13 @@ export function FormItem<
       <InputLabel className="text-black">
         {label}
         {!required && ' (optional)'}
+        {longHint && (
+          <Tooltip title={longHint}>
+            <InfoOutlinedIcon
+              sx={{ verticalAlign: 'bottom', marginLeft: 0.5 }}
+            />
+          </Tooltip>
+        )}
       </InputLabel>
       {children &&
         cloneElement(children, { className: clsx(children.props.className) })}

--- a/packages/mui/src/components/text-array-form-item/TextArrayFormItem.tsx
+++ b/packages/mui/src/components/text-array-form-item/TextArrayFormItem.tsx
@@ -19,6 +19,7 @@ export function TextArrayFormItem<
   label,
   className,
   hint,
+  longHint,
   minimumItemCount,
 }: TextArrayFormItemProps<TSchema>) {
   const { control } = useFormContext();
@@ -39,6 +40,7 @@ export function TextArrayFormItem<
       field={field}
       label={label}
       hint={hint}
+      longHint={longHint}
       disabled={disabled}
       className={className}
     >

--- a/packages/mui/src/components/text-form-item/TextFormItem.tsx
+++ b/packages/mui/src/components/text-form-item/TextFormItem.tsx
@@ -15,6 +15,7 @@ export function TextFormItem<
   label,
   className,
   hint,
+  longHint,
   ...inputProps
 }: TextFormItemProps<TSchema>) {
   const {
@@ -27,6 +28,7 @@ export function TextFormItem<
       field={field}
       label={label}
       hint={hint}
+      longHint={longHint}
       disabled={disabled}
       className={className}
     >

--- a/packages/mui/src/components/textarea-form-item/TextareaFormItem.tsx
+++ b/packages/mui/src/components/textarea-form-item/TextareaFormItem.tsx
@@ -1,19 +1,24 @@
-import { TextField } from "@mui/material";
-import { Controller, useFormContext } from "react-hook-form";
-import type { FormItemProps } from "../form-item/FormItem";
-import { FormItem } from "../form-item/FormItem";
+import { TextField } from '@mui/material';
+import { Controller, useFormContext } from 'react-hook-form';
+import type { FormItemProps } from '../form-item/FormItem';
+import { FormItem } from '../form-item/FormItem';
 
-export type TextareaFormItemProps<TSchema extends Record<string, any> = Record<string, any>> = Omit<FormItemProps<TSchema>, "children"> & {
+export type TextareaFormItemProps<
+  TSchema extends Record<string, any> = Record<string, any>
+> = Omit<FormItemProps<TSchema>, 'children'> & {
   maxLength?: number;
   hint?: string;
 };
 
-export function TextareaFormItem<TSchema extends Record<string, any> = Record<string, any>>({
+export function TextareaFormItem<
+  TSchema extends Record<string, any> = Record<string, any>
+>({
   field,
   disabled,
   label,
   className,
   hint,
+  longHint,
   maxLength,
   ...textAreaProps
 }: TextareaFormItemProps<TSchema>) {
@@ -23,7 +28,14 @@ export function TextareaFormItem<TSchema extends Record<string, any> = Record<st
   } = useFormContext();
   const error = errors[field];
   return (
-    <FormItem field={field} label={label} disabled={disabled} className={className} hint={hint}>
+    <FormItem
+      field={field}
+      label={label}
+      disabled={disabled}
+      className={className}
+      hint={hint}
+      longHint={longHint}
+    >
       <Controller
         name={field}
         control={control}
@@ -32,7 +44,7 @@ export function TextareaFormItem<TSchema extends Record<string, any> = Record<st
             fullWidth
             inputProps={{
               maxLength,
-              "aria-label": label,
+              'aria-label': label,
             }}
             rows={4}
             multiline

--- a/packages/mui/src/components/textfile-form-item/TextfileFormItem.tsx
+++ b/packages/mui/src/components/textfile-form-item/TextfileFormItem.tsx
@@ -11,6 +11,7 @@ export interface TextfileFormItemProps<TSchema extends Record<string, unknown>>
   label: string;
   field: FieldPath<TSchema>;
   hint?: string;
+  longHint?: string;
 }
 
 export function TextfileFormItem<TSchema extends Record<string, unknown>>({
@@ -18,6 +19,7 @@ export function TextfileFormItem<TSchema extends Record<string, unknown>>({
   label,
   field,
   hint,
+  longHint,
   ...fieldProps
 }: TextfileFormItemProps<TSchema>) {
   const { setValue, setError, clearErrors, getValues } =
@@ -36,7 +38,7 @@ export function TextfileFormItem<TSchema extends Record<string, unknown>>({
   );
 
   return (
-    <FormItem label={label} field={field} hint={hint}>
+    <FormItem label={label} field={field} hint={hint} longHint={longHint}>
       <TextfileField
         value={getValues(field) as string}
         onChange={onChange}


### PR DESCRIPTION
Adds `longHint` property to `FormFieldHelper` for each component.

### Video

https://user-images.githubusercontent.com/6289998/229700340-fc95fceb-137b-408c-b921-3f8bf506c394.mp4

