### PR TITLE
fix: pin hookform/resolvers to working version

### DIFF
--- a/.changeset/shaggy-colts-poke.md
+++ b/.changeset/shaggy-colts-poke.md
@@ -1,0 +1,5 @@
+---
+'@makerx/forms-core': patch
+---
+
+pin @hookform/resolvers to <=3.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,7 +1486,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1503,7 +1502,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1520,7 +1518,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1537,7 +1534,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1554,7 +1550,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1571,7 +1566,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1588,7 +1582,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1605,7 +1598,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1622,7 +1614,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1639,7 +1630,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1656,7 +1646,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1673,7 +1662,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1690,7 +1678,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1707,7 +1694,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1724,7 +1710,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1741,7 +1726,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1758,7 +1742,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1775,7 +1758,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1792,7 +1774,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1809,7 +1790,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1826,7 +1806,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1843,7 +1822,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -14823,7 +14801,7 @@
       "name": "@makerx/forms-core",
       "version": "1.1.3",
       "dependencies": {
-        "@hookform/resolvers": "^3.0.0",
+        "@hookform/resolvers": "<=3.2.0",
         "zod": "^3.21.4",
         "zod-form-data": "^2.0.1"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "react-hook-form": "^7.43.7"
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.0.0",
+    "@hookform/resolvers": "<=3.2.0",
     "zod": "^3.21.4",
     "zod-form-data": "^2.0.1"
   },


### PR DESCRIPTION
#  ℹ️ Overview

`@hookform/resolvers` version 3.3.X no longer exports `toNestError`. This PR pins the package to <= `3.2.0`

# 📝 Related Issues:

- fixes #29 